### PR TITLE
dependency fasterxml-classmate

### DIFF
--- a/spring-ai-alibaba-structured-example/output-parser-example/pom.xml
+++ b/spring-ai-alibaba-structured-example/output-parser-example/pom.xml
@@ -38,6 +38,8 @@
 
 		<!-- Spring AI -->
 		<spring-ai-alibaba.version>1.0.0-M3.2</spring-ai-alibaba.version>
+		<fasterxml-classmate.version>1.5.1</fasterxml-classmate.version>
+
 	</properties>
 
 	<dependencies>
@@ -51,6 +53,13 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
+		
+		<dependency>
+			<groupId>com.fasterxml</groupId>
+			<artifactId>classmate</artifactId>
+			<version>${fasterxml-classmate.version}</version>
+		</dependency>
+		
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
dependency fasterxml-classmate to resolve

java.lang.ClassNotFoundException: com.fasterxml.classmate.members.ResolvedMember
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641) ~[na:na]
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188) ~[na:na]
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:525) ~[na:na]
	at com.github.victools.jsonschema.generator.impl.module.FieldExclusionModule.forTransientFields(FieldExclusionModule.java:68) ~[jsonschema-generator-4.35.0.jar:na]....

## What does this PR do?

> Add DashScope LLMs chat example
